### PR TITLE
동아리 상세 정보 페이지 API 연동

### DIFF
--- a/src/components/Common/Button.tsx
+++ b/src/components/Common/Button.tsx
@@ -100,7 +100,7 @@ const StyledButton = styled.button<StyledButtonProps>`
     cursor: pointer;
     transition: all 0.2s ease;
     gap: 10px;
-    line-height: 16.8;
+    line-height: 1.2;
 
     ${({ size }) => getButtonSize(size)}
 

--- a/src/pages/club-detail/ActivityLogModal.tsx
+++ b/src/pages/club-detail/ActivityLogModal.tsx
@@ -1,11 +1,17 @@
+import { apiRequest } from '@/api/axios';
 import { useClickOutside } from '@/hooks/useClickOutside';
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 interface LogMoadlProps {
     setModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
     selectedImageId: number;
     selectedImageUrl: string;
+}
+
+interface ActivityDTO {
+    orderIndex: number;
+    imageUrl: string;
 }
 
 // 여기서 동아리 명, 동아리 이미지도 사용되는데 props로 전달해서 사용해야할지?.?
@@ -15,43 +21,72 @@ const ActivityLogModal = ({
     selectedImageId,
     selectedImageUrl,
 }: LogMoadlProps) => {
-    console.log(selectedImageId, selectedImageUrl); // 이거로 활동로그 api 호출
+    const [activityList, setActivityList] = useState<ActivityDTO[]>();
+    const [currentIdx, setCurrentIdx] = useState<number>(0);
+
+    useEffect(() => {
+        const getActivities = async (activityId: number) => {
+            const response = await apiRequest({
+                url: `/api/activities/${activityId}`,
+            });
+            setActivityList(response.result.activityImageDTOList);
+        };
+        getActivities(selectedImageId);
+    }, [selectedImageId]);
+
+    const handlePrevImage = () => {
+        if (activityList && currentIdx > 0) {
+            setCurrentIdx(currentIdx - 1);
+        }
+    };
+
+    const handleNextImage = () => {
+        if (activityList && currentIdx < activityList.length - 1) {
+            setCurrentIdx(currentIdx + 1);
+        }
+    };
+
     const ref = useRef<HTMLDivElement>(null);
     useClickOutside(ref, () => {
         setModalOpen(false);
     });
     return (
-        <ModalWrapper>
-            <ModalOverlay>
-                <Modal ref={ref}>
-                    <Header>
-                        <ProfileSection>
-                            <ProfileImage
-                                src={selectedImageUrl}
-                                alt="club logo"
+        activityList && (
+            <ModalWrapper>
+                <ModalOverlay>
+                    <Modal ref={ref}>
+                        <Header>
+                            <ProfileSection>
+                                <ProfileImage
+                                    src={selectedImageUrl}
+                                    alt="club logo"
+                                />
+                                <ClubName>UMC ERICA</ClubName>
+                            </ProfileSection>
+                            <CloseButton onClick={() => setModalOpen(false)}>
+                                <ModalX>X</ModalX>
+                            </CloseButton>
+                        </Header>
+                        <ImageSection>
+                            <NavButton onClick={handlePrevImage}>＜</NavButton>
+                            <MainImage
+                                src={activityList[currentIdx].imageUrl}
+                                alt="activity log"
                             />
-                            <ClubName>UMC ERICA</ClubName>
-                        </ProfileSection>
-                        <CloseButton onClick={() => setModalOpen(false)}>
-                            <ModalX>X</ModalX>
-                        </CloseButton>
-                    </Header>
-                    <ImageSection>
-                        <NavButton>{'<'}</NavButton>
-                        <MainImage src={selectedImageUrl} alt="activity log" />
-                        <NavButton>{'>'}</NavButton>
-                    </ImageSection>
-                    <ContentSection>
-                        <Date>2024.11.10</Date>
-                        <Divider />
-                        <Description>
-                            {`UMC에서 GEMINI 지부 MT를 다녀왔어요! 
+                            <NavButton onClick={handleNextImage}>＞</NavButton>
+                        </ImageSection>
+                        <ContentSection>
+                            <Date>2024.11.10</Date>
+                            <Divider />
+                            <Description>
+                                {`UMC에서 GEMINI 지부 MT를 다녀왔어요! 
                                 사진은 김치를 썰고 있는 회장님의 사진이랍니다 ^_^`}
-                        </Description>
-                    </ContentSection>
-                </Modal>
-            </ModalOverlay>
-        </ModalWrapper>
+                            </Description>
+                        </ContentSection>
+                    </Modal>
+                </ModalOverlay>
+            </ModalWrapper>
+        )
     );
 };
 
@@ -128,6 +163,7 @@ const NavButton = styled.button`
     padding-right: 9px;
     padding-top: 6px;
     padding-bottom: 6px;
+    font-weight: 800;
 `;
 
 const MainImage = styled.img`

--- a/src/pages/club-detail/ActivityLogModal.tsx
+++ b/src/pages/club-detail/ActivityLogModal.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 interface LogMoadlProps {
     setModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
-    selectedImageId: string;
+    selectedImageId: number;
     selectedImageUrl: string;
 }
 

--- a/src/pages/club-detail/ActivityLogModal.tsx
+++ b/src/pages/club-detail/ActivityLogModal.tsx
@@ -1,9 +1,12 @@
 import { apiRequest } from '@/api/axios';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import { DEFAULT_CLUB_IMAGE } from '@/utils/getDefaultImg';
 import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 interface LogMoadlProps {
+    clubName?: string | null;
+    clubImg?: string | null;
     setModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
     selectedImageId: number;
     selectedImageUrl: string;
@@ -17,10 +20,13 @@ interface ActivityDTO {
 // 여기서 동아리 명, 동아리 이미지도 사용되는데 props로 전달해서 사용해야할지?.?
 // 이전 이미지 다음 이미지 정보도 API에 담아서 같이 주겠죠?!
 const ActivityLogModal = ({
+    clubName,
+    clubImg,
     setModalOpen,
     selectedImageId,
-    selectedImageUrl,
 }: LogMoadlProps) => {
+    const [modalContent, setModalContent] = useState<string>('');
+    const [modalDate, setModalDate] = useState<string>('');
     const [activityList, setActivityList] = useState<ActivityDTO[]>();
     const [currentIdx, setCurrentIdx] = useState<number>(0);
 
@@ -30,6 +36,8 @@ const ActivityLogModal = ({
                 url: `/api/activities/${activityId}`,
             });
             setActivityList(response.result.activityImageDTOList);
+            setModalContent(response.result.content);
+            setModalDate(response.result.date);
         };
         getActivities(selectedImageId);
     }, [selectedImageId]);
@@ -51,42 +59,47 @@ const ActivityLogModal = ({
         setModalOpen(false);
     });
     return (
-        activityList && (
-            <ModalWrapper>
-                <ModalOverlay>
-                    <Modal ref={ref}>
-                        <Header>
-                            <ProfileSection>
-                                <ProfileImage
-                                    src={selectedImageUrl}
-                                    alt="club logo"
+        <ModalWrapper>
+            <ModalOverlay>
+                <Modal ref={ref}>
+                    {activityList && (
+                        <>
+                            <Header>
+                                <ProfileSection>
+                                    <ProfileImage
+                                        src={clubImg || DEFAULT_CLUB_IMAGE}
+                                        alt="club logo"
+                                    />
+                                    <ClubName>{clubName}</ClubName>
+                                </ProfileSection>
+                                <CloseButton
+                                    onClick={() => setModalOpen(false)}
+                                >
+                                    <ModalX>X</ModalX>
+                                </CloseButton>
+                            </Header>
+                            <ImageSection>
+                                <NavButton onClick={handlePrevImage}>
+                                    ＜
+                                </NavButton>
+                                <MainImage
+                                    src={activityList[currentIdx].imageUrl}
+                                    alt="activity log"
                                 />
-                                <ClubName>UMC ERICA</ClubName>
-                            </ProfileSection>
-                            <CloseButton onClick={() => setModalOpen(false)}>
-                                <ModalX>X</ModalX>
-                            </CloseButton>
-                        </Header>
-                        <ImageSection>
-                            <NavButton onClick={handlePrevImage}>＜</NavButton>
-                            <MainImage
-                                src={activityList[currentIdx].imageUrl}
-                                alt="activity log"
-                            />
-                            <NavButton onClick={handleNextImage}>＞</NavButton>
-                        </ImageSection>
-                        <ContentSection>
-                            <Date>2024.11.10</Date>
-                            <Divider />
-                            <Description>
-                                {`UMC에서 GEMINI 지부 MT를 다녀왔어요! 
-                                사진은 김치를 썰고 있는 회장님의 사진이랍니다 ^_^`}
-                            </Description>
-                        </ContentSection>
-                    </Modal>
-                </ModalOverlay>
-            </ModalWrapper>
-        )
+                                <NavButton onClick={handleNextImage}>
+                                    ＞
+                                </NavButton>
+                            </ImageSection>
+                            <ContentSection>
+                                <Date>{modalDate}</Date>
+                                <Divider />
+                                <Description>{modalContent}</Description>
+                            </ContentSection>
+                        </>
+                    )}
+                </Modal>
+            </ModalOverlay>
+        </ModalWrapper>
     );
 };
 

--- a/src/pages/club-detail/ActivityLogModal.tsx
+++ b/src/pages/club-detail/ActivityLogModal.tsx
@@ -33,20 +33,7 @@ const ActivityLogModal = ({
                             <ClubName>UMC ERICA</ClubName>
                         </ProfileSection>
                         <CloseButton onClick={() => setModalOpen(false)}>
-                            <span
-                                style={{
-                                    alignItems: 'center',
-                                    display: 'flex',
-                                    padding: '5px',
-                                    width: '10px',
-                                    height: '10px',
-                                    fontWeight: '2000',
-                                    fontSize: '20px',
-                                    marginBottom: '9px',
-                                }}
-                            >
-                                x
-                            </span>
+                            <ModalX>X</ModalX>
                         </CloseButton>
                     </Header>
                     <ImageSection>
@@ -168,6 +155,17 @@ const Description = styled.p`
     font-weight: 500;
     font-size: 14px;
     line-height: 18px;
+`;
+
+const ModalX = styled.span`
+    align-items: center;
+    display: flex;
+    padding: 5px;
+    width: 10px;
+    height: 10px;
+    font-weight: 2000;
+    font-size: 20px;
+    margin-bottom: 9px;
 `;
 
 export { ActivityLogModal };

--- a/src/pages/club-detail/ClubDetailPage.tsx
+++ b/src/pages/club-detail/ClubDetailPage.tsx
@@ -16,11 +16,15 @@ interface TabButtonProps {
     $isActive?: boolean;
 }
 
+interface RecruitStateProps {
+    $state?: '모집중' | '모집 예정' | '모집 마감';
+}
+
 // 받을 정보 : id, 이미지, 이름, 태그, 모집상태, 대표, 연락처, 정기모임, 회비, sns, 소개 정보, 모집안내, 활동로그
 
 type activeTab = 'intro' | 'recruit' | 'log';
 
-type recuirementStatus = 'recruiting' | 'upcomming' | 'close'; // 이거 타입명 수정해야함
+type recuirementStatus = 'RECRUITING' | 'UPCOMING' | 'CLOSE'; // 이거 타입명 수정해야함
 
 interface clubInfoSummation {
     name: string | null;
@@ -63,14 +67,18 @@ const ClubDetailPage = () => {
         }
     }, [id]);
     const getRecruitState = () => {
-        if (clubDetail?.recruitmentStatus === 'recruiting') {
-            return '모집중';
-        } else if (clubDetail?.recruitmentStatus === 'upcomming') {
-            return '모집 예정';
-        } else {
-            return '모집 마감';
+        switch (clubDetail?.recruitmentStatus) {
+            case 'RECRUITING':
+                return '모집중';
+            case 'UPCOMING':
+                return '모집 예정';
+            case 'CLOSE':
+                return '모집 마감';
+            default:
+                return '모집 마감'; // clubDetail이 아직 없을 때의 기본값
         }
     };
+
     const [activeTab, setActiveTab] = useState<activeTab>('intro');
     return (
         <PageContainer>
@@ -81,7 +89,11 @@ const ClubDetailPage = () => {
                     <ClubTitle>{clubDetail?.name}</ClubTitle>
                     <ClubTags>
                         <Tag>{clubDetail?.category}</Tag>
-                        <RecruitState>{getRecruitState()}</RecruitState>
+                        {clubDetail && (
+                            <RecruitState $state={getRecruitState()}>
+                                {getRecruitState()}
+                            </RecruitState>
+                        )}
                     </ClubTags>
                 </PreviewWrapper>
             </ClubHeader>
@@ -118,10 +130,10 @@ const ClubDetailPage = () => {
                 </ClubDetails>
             </ClubInfo>
             <Button
-                disabled={clubDetail?.recruitmentStatus === 'recruiting'}
+                disabled={clubDetail?.recruitmentStatus !== 'RECRUITING'}
                 onClick={() => {
                     if (clubDetail?.applicationUrl) {
-                        window.open(clubDetail.applicationUrl, '_blank');
+                        window.open(clubDetail.applicationUrl, '_blank'); // url로 이동
                     }
                 }}
                 size="large"
@@ -213,14 +225,30 @@ const Tag = styled.span`
     color: #33639c;
 `;
 
-const RecruitState = styled.span`
+const RecruitState = styled.span<RecruitStateProps>`
     min-width: 42px;
     height: 18px;
     padding: 2px 5px 2px 5px;
-    border-radius: 5pc;
+    border-radius: 5px;
     font-size: 12px;
-    background-color: #fff4e4;
-    color: #f08a00;
+    background-color: ${(props) => {
+        if (props.$state === '모집중') {
+            return '#fff4e4';
+        } else if (props.$state === '모집 예정') {
+            return '#F1F9DC';
+        } else {
+            return '#F7F7F7';
+        }
+    }};
+    color: ${(props) => {
+        if (props.$state === '모집중') {
+            return '#F08A00';
+        } else if (props.$state === '모집 예정') {
+            return '#8BB421';
+        } else {
+            return '#606060';
+        }
+    }};
 `;
 
 const ClubDetails = styled.div`

--- a/src/pages/club-detail/ClubDetailPage.tsx
+++ b/src/pages/club-detail/ClubDetailPage.tsx
@@ -307,9 +307,9 @@ const TabButton = styled.button<TabButtonProps>`
     background: none;
     border: none;
     border-bottom: 2px solid
-        ${(props) => (props.$isActive ? '#4299e1' : 'transparent')};
-    color: ${(props) => (props.$isActive ? '#4299e1' : '#666')};
-    font-weight: ${(props) => (props.$isActive ? 'bold' : 'normal')};
+        ${(props) => (props.$isActive ? '#33639C' : 'transparent')};
+    color: #000000;
+    font-weight: 500;
     cursor: pointer;
 `;
 

--- a/src/pages/club-detail/ClubDetailPage.tsx
+++ b/src/pages/club-detail/ClubDetailPage.tsx
@@ -138,7 +138,9 @@ const ClubDetailPage = () => {
                 }}
                 size="large"
             >
-                가입 신청하기
+                {clubDetail?.recruitmentStatus !== 'RECRUITING'
+                    ? '모집이 마감되었어요.'
+                    : '가입 신청하기'}
             </Button>
             <TabContainer>
                 <TabButton

--- a/src/pages/club-detail/ClubDetailPage.tsx
+++ b/src/pages/club-detail/ClubDetailPage.tsx
@@ -163,7 +163,12 @@ const ClubDetailPage = () => {
                 </TabButton>
             </TabContainer>
 
-            <TabContents clubId={id} activeTab={activeTab}></TabContents>
+            <TabContents
+                clubName={clubDetail?.name}
+                clubImg={logo}
+                clubId={id}
+                activeTab={activeTab}
+            ></TabContents>
         </PageContainer>
     );
 };

--- a/src/pages/club-detail/TabContents.tsx
+++ b/src/pages/club-detail/TabContents.tsx
@@ -3,17 +3,26 @@ import Log from './tab/Log';
 import Recruit from './tab/Recruit';
 
 interface TabContentsProps {
+    clubName?: string | null;
+    clubImg?: string | null;
     activeTab: string;
     clubId: string;
 }
 
-export default function TabContents({ activeTab, clubId }: TabContentsProps) {
+export default function TabContents({
+    activeTab,
+    clubId,
+    clubName,
+    clubImg,
+}: TabContentsProps) {
     console.log(activeTab);
     if (activeTab === 'intro') {
         return <Intro clubId={clubId}></Intro>;
     } else if (activeTab === 'recruit') {
         return <Recruit clubId={clubId}></Recruit>;
     } else {
-        return <Log clubId={clubId}></Log>;
+        return (
+            <Log clubName={clubName} clubImg={clubImg} clubId={clubId}></Log>
+        );
     }
 }

--- a/src/pages/club-detail/tab/Intro.tsx
+++ b/src/pages/club-detail/tab/Intro.tsx
@@ -1,4 +1,3 @@
-// import { getAccessToken } from '@/api/auth/token';
 import { apiRequest } from '@/api/axios';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
@@ -12,61 +11,45 @@ interface Schedule {
     content: string;
 }
 
-const schedules: Schedule[] = [
-    { month: '3월', content: '3월에 할것' },
-    { month: '4월', content: '4월에 할것' },
-    { month: '6월', content: '6월에 할것' },
-    { month: '7월', content: '7월에 할것' },
-    { month: '8월', content: '8월에 할것' },
-];
-
 export default function Intro({ clubId }: IntroProps) {
-    // const [data, setData] = useState(null);
-    const [userInfo, setUserInfo] = useState(null);
+    const [schedules, setSchedules] = useState<Schedule[]>();
 
     useEffect(() => {
-        // const fetchTest = async () => {
-        //     try {
-        //         const response = await apiRequest({
-        //             url: '/api/documents',
-        //         });
-        //         setData(response);
-        //     } catch (error) {
-        //         console.error('실패:', error);
-        //     }
-        // };
-        const fetchTest2 = async () => {
-            try {
-                const response = await apiRequest({
-                    url: '/api/users/login',
-                    method: 'POST',
-                    data: { code: 'A3T78H' },
-                    requireToken: false,
+        const getSchedules = async (clubId: string) => {
+            if (clubId) {
+                const schedulesResponse = await apiRequest({
+                    url: `/api/clubs/${clubId}/schedules`,
                 });
-                setUserInfo(response);
-                console.log(userInfo);
-            } catch (error) {
-                console.error(error);
+                setSchedules(schedulesResponse.result.activities);
             }
         };
-        fetchTest2();
-        // fetchTest();
+        if (clubId) {
+            getSchedules(clubId);
+        }
     }, [clubId]);
-    // console.log('동아리 소개에서', clubId, userInfo);
-    // console.log('토큰은:', getAccessToken());
-    // 여기 주석 지우면 응답값 확인 가능
     return (
         <div>
             <Container>
                 <Title>🎯 주요 연간일정</Title>
-                <ScheduleContents>
-                    {schedules.map((schedule) => (
-                        <ContentsRow key={schedule.month}>
-                            <ContentsLabel>{schedule.month}</ContentsLabel>
-                            <ContentsValue>{schedule.content}</ContentsValue>
-                        </ContentsRow>
-                    ))}
-                </ScheduleContents>
+                {schedules && schedules.length > 0 ? (
+                    <ScheduleContents>
+                        {schedules.map((schedule) => (
+                            <ContentsRow key={schedule.month}>
+                                <ContentsLabel>
+                                    {schedule.month}월
+                                </ContentsLabel>
+                                <ContentsValue>
+                                    {schedule.content}
+                                </ContentsValue>
+                            </ContentsRow>
+                        ))}
+                    </ScheduleContents>
+                ) : (
+                    <SchedulesNull>
+                        <div>🅧</div>
+                        <div>주요 연간 일정이 비었어요.</div>
+                    </SchedulesNull>
+                )}
             </Container>
             <Container>
                 <ContentBlock>
@@ -141,4 +124,11 @@ const ContentsValue = styled.span`
     font-weight: 500;
     margin-top: 1px;
     margin-left: 7px;
+`;
+
+const SchedulesNull = styled.div`
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+    gap: 8px;
 `;

--- a/src/pages/club-detail/tab/Intro.tsx
+++ b/src/pages/club-detail/tab/Intro.tsx
@@ -10,9 +10,15 @@ interface Schedule {
     month: string;
     content: string;
 }
+interface ClubIntro {
+    introduction: string | null;
+    activity: string | null;
+    recruitment: string | null;
+}
 
 export default function Intro({ clubId }: IntroProps) {
     const [schedules, setSchedules] = useState<Schedule[]>();
+    const [clubIntro, setClubIntro] = useState<ClubIntro>();
 
     useEffect(() => {
         const getSchedules = async (clubId: string) => {
@@ -23,8 +29,17 @@ export default function Intro({ clubId }: IntroProps) {
                 setSchedules(schedulesResponse.result.activities);
             }
         };
+        const getClubIntro = async (clubId: string) => {
+            if (clubId) {
+                const clubIntroResponse = await apiRequest({
+                    url: `/api/clubs/${clubId}/introduction`,
+                });
+                setClubIntro(clubIntroResponse.result);
+            }
+        };
         if (clubId) {
             getSchedules(clubId);
+            getClubIntro(clubId);
         }
     }, [clubId]);
     return (
@@ -54,20 +69,33 @@ export default function Intro({ clubId }: IntroProps) {
             <Container>
                 <ContentBlock>
                     <Title>🔍 우리 동아리를 소개합니다!</Title>
-                    <ContentSpan>
-                        {`첫 번째 줄입니다.
-                        두 번째 줄입니다. 칸이 넘어가면 다음줄로 넘어갑니다아ㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏ
-                        
-                        두 줄 띄우고 세 번째 줄입니다.`}
-                    </ContentSpan>
+                    {clubIntro?.introduction ? (
+                        <ContentSpan>{clubIntro.introduction}</ContentSpan>
+                    ) : (
+                        <ContentSpan>
+                            <div>동아리 소개가 비었어요</div>
+                        </ContentSpan>
+                    )}
                 </ContentBlock>
                 <ContentBlock>
                     <Title>👀 이런 활동을 할 수 있어요!</Title>
-                    <ContentSpan></ContentSpan>
+                    {clubIntro?.activity ? (
+                        <ContentSpan>{clubIntro?.activity}</ContentSpan>
+                    ) : (
+                        <ContentSpan>
+                            <div>동아리 활동 내용이 비었어요</div>
+                        </ContentSpan>
+                    )}
                 </ContentBlock>
                 <ContentBlock>
                     <Title>🔥 너, 내 동료가 돼라!</Title>
-                    <ContentSpan></ContentSpan>
+                    {clubIntro?.recruitment ? (
+                        <ContentSpan>{clubIntro?.recruitment}</ContentSpan>
+                    ) : (
+                        <ContentSpan>
+                            <div>동아리 활동 내용이 비었어요</div>
+                        </ContentSpan>
+                    )}
                 </ContentBlock>
             </Container>
         </div>

--- a/src/pages/club-detail/tab/Intro.tsx
+++ b/src/pages/club-detail/tab/Intro.tsx
@@ -61,7 +61,7 @@ export default function Intro({ clubId }: IntroProps) {
                     </ScheduleContents>
                 ) : (
                     <SchedulesNull>
-                        <div>🅧</div>
+                        <XSize>🅧</XSize>
                         <div>주요 연간 일정이 비었어요.</div>
                     </SchedulesNull>
                 )}
@@ -159,4 +159,8 @@ const SchedulesNull = styled.div`
     flex-direction: column;
     text-align: center;
     gap: 8px;
+`;
+
+const XSize = styled.span`
+    font-size: 30px;
 `;

--- a/src/pages/club-detail/tab/Log.tsx
+++ b/src/pages/club-detail/tab/Log.tsx
@@ -73,7 +73,7 @@ export default function Log({ clubId, clubImg, clubName }: LogProps) {
 const LogGrid = styled.div`
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: 7px;
+    gap: 6px;
 `;
 const Container = styled.div`
     background-color: white;
@@ -83,8 +83,8 @@ const Container = styled.div`
     margin-bottom: 7px;
 `;
 const LogImg = styled.img`
-    width: 95px;
-    height: 95px;
+    width: 92px;
+    height: 92px;
     border-radius: 5px;
 `;
 const NullContainer = styled.div`

--- a/src/pages/club-detail/tab/Log.tsx
+++ b/src/pages/club-detail/tab/Log.tsx
@@ -56,7 +56,7 @@ export default function Log({ clubId }: LogProps) {
                     setModalOpen={setModalOpen}
                     selectedImageId={selectedImageId}
                     selectedImageUrl={selectedImageUrl}
-                ></ActivityLogModal>
+                />
             )}
         </Container>
     ) : (

--- a/src/pages/club-detail/tab/Log.tsx
+++ b/src/pages/club-detail/tab/Log.tsx
@@ -1,63 +1,53 @@
 import styled from 'styled-components';
-import test1 from '../../../assets/common/sns.svg';
-import test2 from '../../../assets/common/sns.svg';
-import test3 from '../../../assets/common/sns.svg';
-import test4 from '../../../assets/common/sns.svg';
-import test5 from '../../../assets/common/sns.svg';
-import test6 from '../../../assets/common/sns.svg';
-import test7 from '../../../assets/common/sns.svg';
-import test8 from '../../../assets/common/sns.svg';
-import test9 from '../../../assets/common/sns.svg';
-import test10 from '../../../assets/common/sns.svg';
-import test11 from '../../../assets/common/sns.svg';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ActivityLogModal } from '../ActivityLogModal';
-
-interface Image {
-    id: string;
-    url: string;
-}
+import { apiRequest } from '@/api/axios';
 
 interface LogProps {
     clubId: string;
 }
 
-const images: Image[] = [
-    { id: 'test1', url: test1 },
-    { id: 'test2', url: test2 },
-    { id: 'test3', url: test3 },
-    { id: 'test4', url: test4 },
-    { id: 'test5', url: test5 },
-    { id: 'test6', url: test6 },
-    { id: 'test7', url: test7 },
-    { id: 'test8', url: test8 },
-    { id: 'test9', url: test9 },
-    { id: 'test10', url: test10 },
-    { id: 'test11', url: test11 },
-];
+interface ActivityThumbnailList {
+    activityId: number;
+    thumbnailUrl: string;
+}
 
 export default function Log({ clubId }: LogProps) {
+    const [activityThumbnailList, setActivityThumbnailList] = useState<
+        ActivityThumbnailList[]
+    >([]);
     const [modalOpen, setModalOpen] = useState<boolean>(false);
-    const [selectedImageId, setSelectedImageId] = useState<string>('');
+    const [selectedImageId, setSelectedImageId] = useState<number>(0);
     const [selectedImageUrl, setSelectedImageUrl] = useState<string>('');
 
-    const handlClickImg = (id: string, url: string) => {
+    useEffect(() => {
+        const getActivityThumbnailList = async (clubId: string) => {
+            const response = await apiRequest({
+                url: `/api/activities/club/${clubId}`,
+            });
+            setActivityThumbnailList(response.result);
+        };
+        getActivityThumbnailList(clubId);
+    }, [clubId]);
+
+    const handlClickImg = (id: number, url: string) => {
         setSelectedImageUrl(url);
         setSelectedImageId(id);
         setModalOpen(true);
     };
-    console.log('활동로그에서', clubId);
-    return (
+    return activityThumbnailList?.length > 0 ? (
         <Container>
             <LogGrid>
-                {images.map((image) => (
+                {activityThumbnailList.map((activity) => (
                     <LogImg
                         onClick={() => {
-                            handlClickImg(image.id, image.url);
+                            handlClickImg(
+                                activity.activityId,
+                                activity.thumbnailUrl,
+                            );
                         }}
-                        key={image.id}
-                        src={image.url}
-                        alt={image.id}
+                        key={activity.activityId}
+                        src={activity.thumbnailUrl}
                     ></LogImg>
                 ))}
             </LogGrid>
@@ -69,6 +59,8 @@ export default function Log({ clubId }: LogProps) {
                 ></ActivityLogModal>
             )}
         </Container>
+    ) : (
+        <div>없음</div>
     );
 }
 const LogGrid = styled.div`

--- a/src/pages/club-detail/tab/Log.tsx
+++ b/src/pages/club-detail/tab/Log.tsx
@@ -25,7 +25,7 @@ export default function Log({ clubId }: LogProps) {
             const response = await apiRequest({
                 url: `/api/activities/club/${clubId}`,
             });
-            setActivityThumbnailList(response.result);
+            setActivityThumbnailList(response.result.activityThumbnailDTOList);
         };
         getActivityThumbnailList(clubId);
     }, [clubId]);

--- a/src/pages/club-detail/tab/Log.tsx
+++ b/src/pages/club-detail/tab/Log.tsx
@@ -60,7 +60,10 @@ export default function Log({ clubId }: LogProps) {
             )}
         </Container>
     ) : (
-        <div>없음</div>
+        <NullContainer>
+            <XSize>🅧</XSize>
+            <span>활동로그가 비었어요.</span>
+        </NullContainer>
     );
 }
 const LogGrid = styled.div`
@@ -79,4 +82,14 @@ const LogImg = styled.img`
     width: 95px;
     height: 95px;
     border-radius: 5px;
+`;
+const NullContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin-top: 81px;
+    gap: 10px;
+    align-items: center;
+`;
+const XSize = styled.span`
+    font-size: 30px;
 `;

--- a/src/pages/club-detail/tab/Log.tsx
+++ b/src/pages/club-detail/tab/Log.tsx
@@ -4,6 +4,8 @@ import { ActivityLogModal } from '../ActivityLogModal';
 import { apiRequest } from '@/api/axios';
 
 interface LogProps {
+    clubName?: string | null;
+    clubImg?: string | null;
     clubId: string;
 }
 
@@ -12,7 +14,7 @@ interface ActivityThumbnailList {
     thumbnailUrl: string;
 }
 
-export default function Log({ clubId }: LogProps) {
+export default function Log({ clubId, clubImg, clubName }: LogProps) {
     const [activityThumbnailList, setActivityThumbnailList] = useState<
         ActivityThumbnailList[]
     >([]);
@@ -53,6 +55,8 @@ export default function Log({ clubId }: LogProps) {
             </LogGrid>
             {modalOpen && (
                 <ActivityLogModal
+                    clubName={clubName}
+                    clubImg={clubImg}
                     setModalOpen={setModalOpen}
                     selectedImageId={selectedImageId}
                     selectedImageUrl={selectedImageUrl}

--- a/src/pages/club-detail/tab/Recruit.tsx
+++ b/src/pages/club-detail/tab/Recruit.tsx
@@ -1,26 +1,51 @@
+import { apiRequest } from '@/api/axios';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 interface RecruitProps {
     clubId: string;
 }
 
+interface RecruitContent {
+    due: string;
+    notice: string;
+    ect: string;
+}
+
 export default function Recruit({ clubId }: RecruitProps) {
-    console.log('모집안내에서', clubId);
-    return (
+    const [recruitContent, setRecruitContent] = useState<RecruitContent>();
+    useEffect(() => {
+        const getRecruit = async (clubId: string) => {
+            const recruitResponse = await apiRequest({
+                url: `/api/clubs/${clubId}/recruitment`,
+            });
+            setRecruitContent(recruitResponse.result);
+        };
+        getRecruit(clubId);
+    }, [clubId]);
+    console.log(recruitContent);
+    return recruitContent?.due &&
+        recruitContent.ect &&
+        recruitContent.notice ? (
         <Container>
             <ContentBlock>
                 <Title>📅 모집기간</Title>
-                <ContentSpan>모집 기간 관련 내용</ContentSpan>
+                <ContentSpan>{recruitContent.due}</ContentSpan>
             </ContentBlock>
             <ContentBlock>
                 <Title>💫 유의사항</Title>
-                <ContentSpan>유의사항 내용</ContentSpan>
+                <ContentSpan>{recruitContent.notice}</ContentSpan>
             </ContentBlock>
             <ContentBlock>
                 <Title>💡 기타 동아리 모집 안내</Title>
-                <ContentSpan>동아리 모집 안내 내용</ContentSpan>
+                <ContentSpan>{recruitContent.ect}</ContentSpan>
             </ContentBlock>
         </Container>
+    ) : (
+        <NullContainer>
+            <XSize>🅧</XSize>
+            <span>모집 안내가 비었습니다.</span>
+        </NullContainer>
     );
 }
 const Container = styled.div`
@@ -44,4 +69,16 @@ const ContentSpan = styled.span`
 const ContentBlock = styled.div`
     width: 278px;
     margin-bottom: 25px;
+`;
+
+const NullContainer = styled.div`
+    margin-top: 80px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    gap: 10px;
+`;
+const XSize = styled.span`
+    font-size: 30px;
 `;

--- a/src/utils/getDefaultImg.ts
+++ b/src/utils/getDefaultImg.ts
@@ -1,0 +1,3 @@
+import img from '../../public/vite.svg';
+
+export const DEFAULT_CLUB_IMAGE = img;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련 이슈번호를 적어주세요 ex) #이슈번호

- #47 

> **해결된 이슈**는 아래 키워드를 사용하여 PR merge 시 자동으로 닫을 수 있습니다 ex) resolve: #123

-resolve: #47 

<br>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- 동아리 상세 페이지에서 필요로 하는 정보 API 호출
- `DEFAULT_CLUB_IMAGE` 라는 변수로 기본 이미지 호출할 수 있도록 변경 -> 추후 로고 생기면 업데이트
- `<Button>` 컴포넌트 line height 잘못 설정해서 클릭 범위 넓어지는 버그 수정

<br>

### 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- @vlmbuyd 혹시 동아리 정보 입력할 때 현재 피그마에 나와있는 것처럼 회비의 경우 ~~'원', SNS의 경우 '@'~~~ 와 같은 형식으로 입력할 수 있는 유효성 검사 절차가 있을까요? 없다면 해당 브랜치에서 뒤에 '원', '@' 이런거 붙여서 렌더링하도록 추가 커밋 올리겠습니다.