### PR TITLE
bugfix: 메인페이지 동아리 검색 개수 제한문제 해결 (#145)

### DIFF
--- a/src/pages/club-list/ClubListPage.tsx
+++ b/src/pages/club-list/ClubListPage.tsx
@@ -318,7 +318,10 @@ const ClubListPage = () => {
     const fetchClubs = useCallback(async () => {
         try {
             setIsLoading(true); // 로딩 상태 설정
-            const params: Record<string, string> = {}; // 쿼리 파라미터 초기화
+            const params: Record<string, string> = {
+                size: '100',  // 충분히 큰 수로 설정하여 모든 데이터를 가져옴
+                page: '0'
+            };
 
             // 필터링 조건만 쿼리 파라미터로 전달
             if (searchTerm.trim()) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련 이슈번호를 적어주세요 ex) #이슈번호

- #145 

<br>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- 메인페이지에 검색되는 동아리 개수가 10개 (백엔드에서 넘겨주는 기본값)만 보이는 문제해결
- 기본값 대신에 size를 100으로 넉넉하게 잡아서 데이터베이스에 있는 모든 값을 가져온후에 프론트에서 필터링하는 방식

<br>

### 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
