### PR TITLE
동아리 등록 시 나타나는 에러가 사진 용량 때문일 때 toast 메세지 띄우기 및 동아리 상세 페이지 각종 버그 수정

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -7,7 +7,7 @@ export const axiosInstance: AxiosInstance = axios.create({
     headers: {
         'Content-Type': 'application/json', // null로 해둬도 axios가 알아서 객체 감지한다고 합니다
     },
-    timeout: 3000,
+    timeout: 7000,
 });
 
 axiosInstance.interceptors.response.use(

--- a/src/constants/MAX_FILE_SIZE.ts
+++ b/src/constants/MAX_FILE_SIZE.ts
@@ -1,0 +1,1 @@
+export const MAX_FILE_SIZE = 6 * 1024 * 1024; // 넉넉잡아 6메가까지 업로드 가능하도록

--- a/src/constants/MAX_FILE_SIZE.ts
+++ b/src/constants/MAX_FILE_SIZE.ts
@@ -1,1 +1,1 @@
-export const MAX_FILE_SIZE = 6 * 1024 * 1024; // 넉넉잡아 6메가까지 업로드 가능하도록
+export const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1메가

--- a/src/hooks/queries/useClubRegisterQueries.ts
+++ b/src/hooks/queries/useClubRegisterQueries.ts
@@ -127,7 +127,7 @@ function useClubRegisterQueries() {
                     method: 'POST',
                     data: formData,
                     headers: {
-                        'Content-Type': 'multipart/form-data',
+                        'Content-Type': 'multipart/-data',
                     },
                     requireToken: true,
                 });

--- a/src/hooks/queries/useClubRegisterQueries.ts
+++ b/src/hooks/queries/useClubRegisterQueries.ts
@@ -8,6 +8,8 @@ import { useNavigate } from 'react-router-dom';
 import { useToast } from '../actions/useToast';
 import { useRecoilValue } from 'recoil';
 import { clubIdSelector } from '@/store/clubInfoState';
+import { MAX_FILE_SIZE } from '@/constants/MAX_FILE_SIZE';
+import { calculateFormDataSize } from '@/utils/calculateFileSize';
 
 function useClubRegisterQueries() {
     const clubId = useRecoilValue(clubIdSelector);
@@ -61,22 +63,6 @@ function useClubRegisterQueries() {
                 console.error('동아리 등록 정보 불러오기 실패');
             }
         }, [isSuccess, data]);
-    };
-
-    const MAX_FILE_SIZE = 6 * 1024 * 1024; // 넉넉잡아 6메가까지 업로드 가능하도록
-
-    const calculateFormDataSize = (formData: FormData): number => {
-        let totalSize = 0;
-
-        for (const pair of formData.entries()) {
-            const value = pair[1];
-            if (value instanceof File) {
-                totalSize += value.size;
-            } else if (typeof value === 'string') {
-                totalSize += new Blob([value]).size;
-            }
-        }
-        return totalSize;
     };
 
     // 동아리 등록

--- a/src/hooks/queries/useClubRegisterQueries.ts
+++ b/src/hooks/queries/useClubRegisterQueries.ts
@@ -100,7 +100,7 @@ function useClubRegisterQueries() {
             if (totalSize > MAX_FILE_SIZE) {
                 showToast(
                     `파일 크기가 너무 큽니다. 최대 ${
-                        5
+                        0.5
                         // MAX_FILE_SIZE / 1024 / 1024
                     }MB까지 가능합니다.`,
                 );
@@ -152,7 +152,7 @@ function useClubRegisterQueries() {
             if (totalSize > MAX_FILE_SIZE) {
                 showToast(
                     `파일 크기가 너무 큽니다. 최대 ${
-                        5
+                        0.5
                         // MAX_FILE_SIZE / 1024 / 1024
                     }MB까지 가능합니다.`,
                 );

--- a/src/pages/club-detail/ClubDetailPage.tsx
+++ b/src/pages/club-detail/ClubDetailPage.tsx
@@ -25,7 +25,7 @@ interface RecruitStateProps {
 
 type activeTab = 'intro' | 'recruit' | 'log';
 
-type recuirementStatus = 'RECRUITING' | 'UPCOMING' | 'CLOSE';
+type recuirementStatus = 'RECRUITING' | 'OPEN' | 'CLOSE';
 
 interface clubInfoSummation {
     name: string | null;
@@ -133,7 +133,7 @@ const ClubDetailPage = () => {
         switch (clubDetail?.recruitmentStatus) {
             case 'RECRUITING':
                 return '모집중';
-            case 'UPCOMING':
+            case 'OPEN':
                 return '모집 예정';
             case 'CLOSE':
                 return '모집 마감';

--- a/src/pages/club-detail/ClubDetailPage.tsx
+++ b/src/pages/club-detail/ClubDetailPage.tsx
@@ -13,6 +13,7 @@ import { ClubDetailProvider } from '@/contexts/ClubDetailContext';
 import { getCategoryEmoji, getCategoryMapping } from '@/utils/getCategoryEmoji';
 import arrow from '../../assets/common/Expand_right.svg';
 import { DEFAULT_IMG } from '@/constants/DEFAULT_IMG';
+import { isValidUrl } from '@/utils/isValidUrl';
 
 // tab 항목에서 활성화 여부를 판단할 props
 interface TabButtonProps {
@@ -238,7 +239,8 @@ const ClubDetailPage = () => {
                         <Button
                             disabled={
                                 clubDetail?.recruitmentStatus !== 'OPEN' ||
-                                clubDetail.applicationUrl === '없음'
+                                clubDetail.applicationUrl === '없음' ||
+                                !isValidUrl(clubDetail?.applicationUrl)
                             }
                             onClick={() => {
                                 if (clubDetail?.applicationUrl) {

--- a/src/pages/club-detail/ClubDetailPage.tsx
+++ b/src/pages/club-detail/ClubDetailPage.tsx
@@ -20,12 +20,12 @@ interface TabButtonProps {
 }
 
 interface RecruitStateProps {
-    $state?: '모집중' | '모집 예정' | '모집 마감';
+    $state?: '모집 중' | '모집 예정' | '모집 마감';
 }
 
 type activeTab = 'intro' | 'recruit' | 'log';
 
-type recuirementStatus = 'RECRUITING' | 'OPEN' | 'CLOSE';
+type recuirementStatus = 'UPCOMING' | 'OPEN' | 'CLOSED';
 
 interface clubInfoSummation {
     name: string | null;
@@ -61,7 +61,7 @@ const ClubDetailPage = () => {
         activities: '없음',
         membershipFee: '없음',
         snsUrl: '없음',
-        recruitmentStatus: 'CLOSE',
+        recruitmentStatus: 'CLOSED',
         applicationUrl: '없음',
         profileImageUrl: null,
     });
@@ -131,11 +131,11 @@ const ClubDetailPage = () => {
     }, [id, nowUrl]);
     const getRecruitState = () => {
         switch (clubDetail?.recruitmentStatus) {
-            case 'RECRUITING':
-                return '모집중';
-            case 'OPEN':
+            case 'UPCOMING':
                 return '모집 예정';
-            case 'CLOSE':
+            case 'OPEN':
+                return '모집 중';
+            case 'CLOSED':
                 return '모집 마감';
             default:
                 return '모집 마감'; // clubDetail이 아직 없을 때의 기본값
@@ -237,7 +237,8 @@ const ClubDetailPage = () => {
                     {nowUrl === 'club' && (
                         <Button
                             disabled={
-                                clubDetail?.recruitmentStatus !== 'RECRUITING'
+                                clubDetail?.recruitmentStatus !== 'OPEN' ||
+                                clubDetail.applicationUrl === '없음'
                             }
                             onClick={() => {
                                 if (clubDetail?.applicationUrl) {
@@ -249,7 +250,7 @@ const ClubDetailPage = () => {
                             }}
                             size="large"
                         >
-                            {clubDetail?.recruitmentStatus !== 'RECRUITING'
+                            {clubDetail?.recruitmentStatus !== 'OPEN'
                                 ? '모집이 마감되었어요.'
                                 : '가입 신청하기'}
                         </Button>
@@ -365,7 +366,7 @@ const RecruitState = styled.span<RecruitStateProps>`
     align-items: center;
 
     background-color: ${(props) => {
-        if (props.$state === '모집중') {
+        if (props.$state === '모집 중') {
             return '#fff4e4';
         } else if (props.$state === '모집 예정') {
             return '#F1F9DC';
@@ -374,7 +375,7 @@ const RecruitState = styled.span<RecruitStateProps>`
         }
     }};
     color: ${(props) => {
-        if (props.$state === '모집중') {
+        if (props.$state === '모집 중') {
             return '#F08A00';
         } else if (props.$state === '모집 예정') {
             return '#8BB421';

--- a/src/pages/club-detail/tab/Log.tsx
+++ b/src/pages/club-detail/tab/Log.tsx
@@ -70,8 +70,10 @@ export default function Log() {
         </Container>
     ) : (
         <NullContainer>
-            <XSize>🅧</XSize>
-            <span>활동로그가 비었어요.</span>
+            <ContainerV>
+                <XSize>🅧</XSize>
+                <span>활동로그가 비었어요.</span>
+            </ContainerV>
         </NullContainer>
     );
 }
@@ -87,6 +89,16 @@ const Container = styled.div`
     width: 328px;
     margin-bottom: 7px;
 `;
+const ContainerV = styled.div`
+    background-color: white;
+    border-radius: 10px;
+    padding: 20px;
+    width: 328px;
+    margin-bottom: 7px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+`;
 const LogImg = styled.img`
     width: 92px;
     height: 92px;
@@ -95,9 +107,8 @@ const LogImg = styled.img`
 const NullContainer = styled.div`
     display: flex;
     flex-direction: column;
-    margin-top: 81px;
-    gap: 10px;
-    align-items: center;
+    justify-content: center;
+    text-align: center;
 `;
 const XSize = styled.span`
     font-size: 30px;

--- a/src/pages/club-detail/tab/Log.tsx
+++ b/src/pages/club-detail/tab/Log.tsx
@@ -90,7 +90,7 @@ const Container = styled.div`
     margin-bottom: 7px;
 `;
 const ContainerV = styled.div`
-    background-color: white;
+    background-color: none;
     border-radius: 10px;
     padding: 20px;
     width: 328px;

--- a/src/pages/club-detail/tab/Recruit.tsx
+++ b/src/pages/club-detail/tab/Recruit.tsx
@@ -84,7 +84,7 @@ const Container = styled.div`
     margin-bottom: 7px;
 `;
 const ContainerV = styled.div`
-    background-color: white;
+    background-color: none;
     border-radius: 10px;
     padding: 20px;
     width: 328px;

--- a/src/pages/club-detail/tab/Recruit.tsx
+++ b/src/pages/club-detail/tab/Recruit.tsx
@@ -69,8 +69,10 @@ export default function Recruit() {
         </Container>
     ) : (
         <NullContainer>
-            <XSize>🅧</XSize>
-            <span>모집 안내가 비었습니다.</span>
+            <ContainerV>
+                <XSize>🅧</XSize>
+                <span>모집 안내가 비었습니다.</span>
+            </ContainerV>
         </NullContainer>
     );
 }
@@ -80,6 +82,16 @@ const Container = styled.div`
     padding: 20px;
     width: 328px;
     margin-bottom: 7px;
+`;
+const ContainerV = styled.div`
+    background-color: white;
+    border-radius: 10px;
+    padding: 20px;
+    width: 328px;
+    margin-bottom: 7px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 `;
 const Title = styled.div`
     margin-top: -5px;
@@ -98,12 +110,10 @@ const ContentBlock = styled.div`
 `;
 
 const NullContainer = styled.div`
-    margin-top: 80px;
     display: flex;
     flex-direction: column;
     justify-content: center;
     text-align: center;
-    gap: 10px;
 `;
 const XSize = styled.span`
     font-size: 30px;

--- a/src/utils/calculateFileSize.ts
+++ b/src/utils/calculateFileSize.ts
@@ -1,0 +1,13 @@
+export const calculateFormDataSize = (formData: FormData): number => {
+    let totalSize = 0;
+
+    for (const pair of formData.entries()) {
+        const value = pair[1];
+        if (value instanceof File) {
+            totalSize += value.size;
+        } else if (typeof value === 'string') {
+            totalSize += new Blob([value]).size;
+        }
+    }
+    return totalSize;
+};

--- a/src/utils/isValidUrl.ts
+++ b/src/utils/isValidUrl.ts
@@ -1,0 +1,14 @@
+export const isValidUrl = (url: string | null | undefined) => {
+    // url이 undefined, null, '없음' 또는 빈 문자열인 경우 유효하지 않음
+    if (!url || url === '없음' || url === '') return false;
+
+    try {
+        // URL 객체 생성 시도 (잘못된 URL 형식이면 에러 발생)
+        new URL(url);
+
+        // 유효한 프로토콜인지 확인 (http 또는 https로 시작하는지)
+        return url.startsWith('http://') || url.startsWith('https://');
+    } catch (error) {
+        return false;
+    }
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련 이슈번호를 적어주세요 ex) #이슈번호

- #147 

<br>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- POST 요청 보내는 내용의 Size를 계산한후 렌더링 되는 값 기준(5메가)보다 넉넉하게 6메가(최대 10메가라고 하셔서)로 설정하여 그 이상 크기의 파일을 업로드할 시 toast 메세지 띄우도록 수정하였습니다.
- 기존에 파일 사이즈 때문에 업로드가 안 될 때 응답이 즉각 오지 않아서 `/api/axiosInstance.ts`의 `timeout:3000`에 걸려서 정확한 원인을 알 수 없었기 때문에 시간 제한도 7초로 늘렸습니다.
<br>

### 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 수립님은 정상적으로 작동하는지 확인 부탁드립니다.
- 예안님은 바쁘실테니 시간 나면 충돌 나는지만 확인 부탁드리고 여유 없으시면 일단 머지하겠습니다!\
- 1시간 뒤에 머지할게요!
