### PR TITLE
검색 탭 드롭다운 z-index 버그 수정

### DIFF
--- a/src/domains/shared/components/search/ClubSearchWidget.tsx
+++ b/src/domains/shared/components/search/ClubSearchWidget.tsx
@@ -101,7 +101,7 @@ export default function ClubSearchWidget({
     return (
         <div className="min-h-screen flex flex-col">
             <div className="flex-1 flex flex-col items-center">
-                <div className="sticky top-[56px] z-10 w-full bg-white flex justify-center">
+                <div className="sticky top-[56px] z-20 w-full bg-white flex justify-center">
                     <SearchTab />
                 </div>
                 <div className="flex flex-col items-center py-5">

--- a/src/pages/social/ClubSocialPage.tsx
+++ b/src/pages/social/ClubSocialPage.tsx
@@ -73,7 +73,7 @@ export default function ClubSocialPage() {
     return (
         <div className="min-h-screen flex flex-col">
             <div className="flex-1 flex flex-col items-center">
-                <div className="sticky top-[56px] z-10 w-full bg-white flex justify-center h-[47px]">
+                <div className="sticky top-[56px] z-20 w-full bg-white flex justify-center h-[47px]">
                     <SearchTab />
                 </div>
 


### PR DESCRIPTION
드롭다운 활성화 상태에서 스크롤 시 드롭다운이 검색 탭의 z-index보다 앞에서 렌더링되는 버그 수정

## #️⃣ 연관된 이슈

> 관련 이슈번호를 적어주세요 ex) #이슈번호

- #285

<br>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- 드롭다운 활성화 상태에서 스크롤 시 드롭다운이 검색 탭의 z-index보다 앞에서 렌더링되는 버그 발생 
  -> `<SearchTab />` `z-index`를 드롭다운보다 높게 주어 해결
- 버그 발생 페이지
  - 검색 카테고리 페이지
  - 공식 계정 페이지


<br>

### 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
